### PR TITLE
feat: multi-layer inference (v0.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Markdown docs (plans, specs, review reports — kept local only)
 *.md
 !README.md
+!CLAUDE.md
 docs/
 
 build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# MicroMind-Anomaly
+
+Tiny anomaly-detection inference library for embedded 3D printer safety.
+
+## Language & Standard
+
+- **C++14** (overrides global `~/.claude/CLAUDE.md` C++20 convention)
+- Compiler: GCC 12+ / Clang 15+ / MSVC 17.5+
+- Build: CMake 3.25+, Ninja recommended
+
+## Hard Constraints
+
+| Constraint | Rationale |
+|------------|-----------|
+| **No heap allocation** | `std::vector`, `new`, `malloc` prohibited. Static arrays and `std::array` only. |
+| **No exceptions** | `-fno-exceptions` enforced. No `throw`, no `try`/`catch` in library code. |
+| **Single-threaded** | No mutexes, atomics, or thread-local storage. |
+| **Weights in ROM** | `static const` arrays placed in `.rodata` at link time. No runtime loading (until v0.5). |
+| **Binary size** | Target: <= 32 KB flash (STM32F4 baseline). |
+
+## Build Commands
+
+```bash
+cmake -S . -B build -G Ninja
+cmake --build build
+./build/tests/micromind_tests        # or micromind_tests.exe on Windows
+```
+
+## Project Structure
+
+```
+include/micromind/     # Public headers (config, detector, inference_engine, ring_buffer)
+src/                   # Implementation files
+tests/                 # GoogleTest unit tests
+docs/                  # Design specs (gitignored)
+tools/                 # Scripts and utilities (future)
+```
+
+## Testing
+
+- Framework: GoogleTest 1.14.0 (fetched via CMake FetchContent)
+- Tests compile without `-fno-exceptions` (GoogleTest requires exceptions)
+- All tests must pass under `-Wall -Wextra -Werror`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@ docs/                  # Design specs (gitignored)
 tools/                 # Scripts and utilities (future)
 ```
 
+## Naming Override
+
+Free functions in the `micromind` namespace use **snake_case** (e.g., `mat_vec_mul`, `relu`, `dense_forward`). This overrides the global PascalCase convention for functions — it matches the existing codebase and is consistent with C++ standard library style, which is more natural for a low-level embedded library.
+
 ## Testing
 
 - Framework: GoogleTest 1.14.0 (fetched via CMake FetchContent)

--- a/include/micromind/config.h
+++ b/include/micromind/config.h
@@ -1,9 +1,18 @@
 #pragma once
+#include <cstddef>
 #include <cstdint>
 
 namespace micromind {
-    static constexpr uint32_t RING_BUFFER_CAPACITY = 32;
-    static constexpr float ANOMALY_THRESHOLD = 0.5f;
-    static constexpr uint32_t INPUT_FEATURES  = 4;
-    static constexpr uint32_t OUTPUT_FEATURES = 1;
+    static constexpr uint32_t    RING_BUFFER_CAPACITY = 32;
+    static constexpr float       ANOMALY_THRESHOLD    = 0.5f;
+    static constexpr std::size_t INPUT_FEATURES       = 4;
+    static constexpr std::size_t OUTPUT_FEATURES      = 1;
+    static constexpr std::size_t HIDDEN_UNITS         = 8;
+    static constexpr float       LAYER1_BIAS_INIT     = 0.0f;
+    static constexpr float       LAYER2_BIAS_INIT     = 0.0f;
+
+    static_assert(HIDDEN_UNITS <= 64,
+                  "HIDDEN_UNITS exceeds safe stack budget for embedded targets");
+    static_assert(OUTPUT_FEATURES == 1,
+                  "Detector callback logic assumes single-output inference");
 } // namespace micromind

--- a/include/micromind/config.h
+++ b/include/micromind/config.h
@@ -3,16 +3,20 @@
 #include <cstdint>
 
 namespace micromind {
-    static constexpr uint32_t    RING_BUFFER_CAPACITY = 32;
-    static constexpr float       ANOMALY_THRESHOLD    = 0.5f;
-    static constexpr std::size_t INPUT_FEATURES       = 4;
-    static constexpr std::size_t OUTPUT_FEATURES      = 1;
-    static constexpr std::size_t HIDDEN_UNITS         = 8;
-    static constexpr float       LAYER1_BIAS_INIT     = 0.0f;
-    static constexpr float       LAYER2_BIAS_INIT     = 0.0f;
+    constexpr uint32_t    RING_BUFFER_CAPACITY = 32;
+    constexpr float       ANOMALY_THRESHOLD    = 0.5f;
+    constexpr std::size_t INPUT_FEATURES       = 4;
+    constexpr std::size_t OUTPUT_FEATURES      = 1;
+    constexpr std::size_t HIDDEN_UNITS         = 8;
+    constexpr float       LAYER1_BIAS_INIT     = 0.0f;
+    constexpr float       LAYER2_BIAS_INIT     = 0.0f;
 
+    static_assert(HIDDEN_UNITS >= 1,
+                  "HIDDEN_UNITS must be at least 1");
     static_assert(HIDDEN_UNITS <= 64,
                   "HIDDEN_UNITS exceeds safe stack budget for embedded targets");
     static_assert(OUTPUT_FEATURES == 1,
                   "Detector callback logic assumes single-output inference");
+    static_assert(RING_BUFFER_CAPACITY >= INPUT_FEATURES,
+                  "Ring buffer must hold at least one full input window");
 } // namespace micromind

--- a/include/micromind/detector.h
+++ b/include/micromind/detector.h
@@ -13,9 +13,12 @@ using StopCallback = void(*)();
 // ---------------------------------------------------------------------------
 // Detector
 //
-// Accumulates sensor values in a fixed-capacity ring buffer and runs a single
-// dense-layer inference pass every time a new sample arrives.  When the
-// activation exceeds ANOMALY_THRESHOLD the registered StopCallback is fired.
+// Accumulates sensor values in a fixed-capacity ring buffer and runs a
+// two-layer dense inference pass every time a new sample arrives:
+//   Layer 1: INPUT_FEATURES -> HIDDEN_UNITS (ReLU)
+//   Layer 2: HIDDEN_UNITS   -> OUTPUT_FEATURES (no activation)
+// When the output exceeds ANOMALY_THRESHOLD the registered StopCallback
+// is fired.
 //
 // Memory model: all storage is static.  No heap, no exceptions.
 // Thread safety: none — single-threaded embedded use only.
@@ -36,11 +39,9 @@ private:
     RingBuffer<float, RING_BUFFER_CAPACITY> buffer_;
     StopCallback callback_ = nullptr;
 
-    // weights_ is intentionally NOT a static class member to avoid the C++14
-    // ODR requirement for an out-of-class definition when the array is
-    // passed by reference to mat_vec_mul.  It is instead a function-local
-    // static const inside push_sensor_value, placed in .rodata at link time.
-    // See detector.cpp for the actual values.
+    // Weights and biases are function-local static const inside
+    // push_sensor_value() to avoid C++14 ODR issues and ensure .rodata
+    // placement. See detector.cpp for values.
 };
 
 } // namespace micromind

--- a/include/micromind/detector.h
+++ b/include/micromind/detector.h
@@ -33,15 +33,18 @@ public:
     // INPUT_FEATURES samples (zero-padded if fewer are available).
     // If the output exceeds ANOMALY_THRESHOLD and a callback is registered,
     // the callback is called synchronously before this function returns.
+    // Non-finite inputs (NaN, Inf) are treated as immediate anomalies.
+    // Not reentrant — must not be called from within the StopCallback.
     void push_sensor_value(float value);
 
 private:
     RingBuffer<float, RING_BUFFER_CAPACITY> buffer_;
     StopCallback callback_ = nullptr;
+    bool in_push_ = false;
 
     // Weights and biases are function-local static const inside
     // push_sensor_value() to avoid C++14 ODR issues and ensure .rodata
-    // placement. See detector.cpp for values.
+    // placement. See detector.cpp for placeholder values.
 };
 
 } // namespace micromind

--- a/include/micromind/inference_engine.h
+++ b/include/micromind/inference_engine.h
@@ -48,4 +48,43 @@ void relu(std::array<float, N>& arr)
     }
 }
 
+// ---------------------------------------------------------------------------
+// Activation
+//
+// Tag type selecting the activation function applied after the dense layer.
+// kRelu  — clamp negatives to zero (hidden layers)
+// kNone  — pass-through (output layer)
+// ---------------------------------------------------------------------------
+enum class Activation { kRelu, kNone };
+
+// ---------------------------------------------------------------------------
+// dense_forward
+//
+// Composes a full dense layer pass: matrix-vector multiply, bias addition,
+// and optional activation.
+//
+// Zeroing contract: output is zeroed by mat_vec_mul before accumulation.
+// dense_forward does not zero independently.
+//
+// The activation branch is a runtime 'if' in C++14. At -O2 the compiler
+// optimises for the two known call sites.
+// ---------------------------------------------------------------------------
+template<std::size_t Rows, std::size_t Cols>
+void dense_forward(const float (&weights)[Rows][Cols],
+                   const std::array<float, Rows>& bias,
+                   const std::array<float, Cols>& input,
+                   std::array<float, Rows>& output,
+                   Activation act)
+{
+    mat_vec_mul(weights, input, output);
+
+    for (std::size_t i = 0; i < Rows; ++i) {
+        output[i] += bias[i];
+    }
+
+    if (act == Activation::kRelu) {
+        relu(output);
+    }
+}
+
 } // namespace micromind

--- a/include/micromind/inference_engine.h
+++ b/include/micromind/inference_engine.h
@@ -51,9 +51,9 @@ void relu(std::array<float, N>& arr)
 // ---------------------------------------------------------------------------
 // Activation
 //
-// Tag type selecting the activation function applied after the dense layer.
+// Selects the activation function applied after the dense layer.
 // kRelu  — clamp negatives to zero (hidden layers)
-// kNone  — pass-through (output layer)
+// kNone  — identity / pass-through (output layer)
 // ---------------------------------------------------------------------------
 enum class Activation { kRelu, kNone };
 
@@ -64,10 +64,12 @@ enum class Activation { kRelu, kNone };
 // and optional activation.
 //
 // Zeroing contract: output is zeroed by mat_vec_mul before accumulation.
-// dense_forward does not zero independently.
+// dense_forward does not zero independently — callers need not initialize
+// the output array before calling.
 //
-// The activation branch is a runtime 'if' in C++14. At -O2 the compiler
-// optimises for the two known call sites.
+// The activation branch is a runtime switch; each template instantiation
+// at a concrete call site allows the compiler to eliminate the dead branch
+// after inlining.
 // ---------------------------------------------------------------------------
 template<std::size_t Rows, std::size_t Cols>
 void dense_forward(const float (&weights)[Rows][Cols],
@@ -82,8 +84,12 @@ void dense_forward(const float (&weights)[Rows][Cols],
         output[i] += bias[i];
     }
 
-    if (act == Activation::kRelu) {
-        relu(output);
+    switch (act) {
+        case Activation::kRelu:
+            relu(output);
+            break;
+        case Activation::kNone:
+            break;
     }
 }
 

--- a/src/detector.cpp
+++ b/src/detector.cpp
@@ -22,18 +22,17 @@ void Detector::push_sensor_value(float value) {
     // ---------------------------------------------------------------------------
     std::array<float, INPUT_FEATURES> input{};
 
-    uint32_t available = buffer_.size();
+    const uint32_t available = buffer_.size();
 
     // 'start' is the logical index of the oldest sample we want to copy.
-    // If available >= INPUT_FEATURES we skip the oldest (available - INPUT_FEATURES)
-    // samples and begin at that offset; otherwise we start at 0 and the
-    // remaining slots stay at zero (from the value-initialisation above).
-    uint32_t start = (available >= INPUT_FEATURES)
-                         ? (available - INPUT_FEATURES)
-                         : 0u;
+    // If available >= INPUT_FEATURES we skip the oldest samples;
+    // otherwise we start at 0 and remaining slots stay zero-padded.
+    const uint32_t start = (available >= static_cast<uint32_t>(INPUT_FEATURES))
+                               ? (available - static_cast<uint32_t>(INPUT_FEATURES))
+                               : 0u;
 
-    for (uint32_t i = 0u; i < INPUT_FEATURES; ++i) {
-        uint32_t idx = start + i;   // both operands are uint32_t — no signed/unsigned warning
+    for (uint32_t i = 0u; i < static_cast<uint32_t>(INPUT_FEATURES); ++i) {
+        const uint32_t idx = start + i;
         if (idx < available) {
             input[i] = buffer_[idx];
         }
@@ -41,23 +40,39 @@ void Detector::push_sensor_value(float value) {
     }
 
     // ---------------------------------------------------------------------------
-    // Dummy 1-output dense layer.
+    // Two-layer forward pass.
     //
-    // weights_ is a function-local static const so it lives in .rodata with no
-    // dynamic allocation and no C++14 ODR out-of-class definition required.
-    // All weights are 0.25f: with INPUT_FEATURES=4 inputs at full scale this
-    // yields a max raw output of 1.0f, which is above ANOMALY_THRESHOLD=0.5f,
-    // giving a testable range for integration tests.
+    // All weights and biases are function-local static const arrays placed in
+    // .rodata at link time. Placeholder values use uniform reciprocals for
+    // hand-computable test expectations. Replace with trained weights via the
+    // export pipeline (v0.5).
     //
-    // Replace this array with real trained weights once calibrated on hardware.
+    // Layer 1: INPUT_FEATURES -> HIDDEN_UNITS, ReLU activation
+    // Layer 2: HIDDEN_UNITS   -> OUTPUT_FEATURES, no activation (raw score)
     // ---------------------------------------------------------------------------
-    static const float weights[OUTPUT_FEATURES][INPUT_FEATURES] = {
-        { 0.25f, 0.25f, 0.25f, 0.25f }
+    static const float weights_l1[HIDDEN_UNITS][INPUT_FEATURES] = {
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f}
     };
+    static const std::array<float, HIDDEN_UNITS> bias_l1 = {};
 
+    static const float weights_l2[OUTPUT_FEATURES][HIDDEN_UNITS] = {
+        {0.125f, 0.125f, 0.125f, 0.125f,
+         0.125f, 0.125f, 0.125f, 0.125f}
+    };
+    static const std::array<float, OUTPUT_FEATURES> bias_l2 = {};
+
+    std::array<float, HIDDEN_UNITS> hidden{};
     std::array<float, OUTPUT_FEATURES> output{};
-    mat_vec_mul(weights, input, output);
-    relu(output);
+
+    dense_forward(weights_l1, bias_l1, input, hidden, Activation::kRelu);
+    dense_forward(weights_l2, bias_l2, hidden, output, Activation::kNone);
 
     // Fire the callback synchronously if an anomaly is detected.
     // The null-check avoids a branch-to-null fault on targets with no MMU.

--- a/src/detector.cpp
+++ b/src/detector.cpp
@@ -60,13 +60,16 @@ void Detector::push_sensor_value(float value) {
         {0.25f, 0.25f, 0.25f, 0.25f},
         {0.25f, 0.25f, 0.25f, 0.25f}
     };
-    static const std::array<float, HIDDEN_UNITS> bias_l1 = {};
+    static const std::array<float, HIDDEN_UNITS> bias_l1 = {
+        LAYER1_BIAS_INIT, LAYER1_BIAS_INIT, LAYER1_BIAS_INIT, LAYER1_BIAS_INIT,
+        LAYER1_BIAS_INIT, LAYER1_BIAS_INIT, LAYER1_BIAS_INIT, LAYER1_BIAS_INIT
+    };
 
     static const float weights_l2[OUTPUT_FEATURES][HIDDEN_UNITS] = {
         {0.125f, 0.125f, 0.125f, 0.125f,
          0.125f, 0.125f, 0.125f, 0.125f}
     };
-    static const std::array<float, OUTPUT_FEATURES> bias_l2 = {};
+    static const std::array<float, OUTPUT_FEATURES> bias_l2 = {LAYER2_BIAS_INIT};
 
     std::array<float, HIDDEN_UNITS> hidden{};
     std::array<float, OUTPUT_FEATURES> output{};

--- a/src/detector.cpp
+++ b/src/detector.cpp
@@ -1,5 +1,6 @@
 #include "micromind/detector.h"
 #include <array>
+#include <cmath>
 #include <cstdint>
 
 namespace micromind {
@@ -9,6 +10,22 @@ void Detector::register_callback(StopCallback cb) {
 }
 
 void Detector::push_sensor_value(float value) {
+    // Reentrance guard: calling push_sensor_value from within the
+    // StopCallback would cause unbounded recursion on a small stack.
+    if (in_push_) { return; }
+    in_push_ = true;
+
+    // Reject non-finite sensor values at the boundary. A NaN or Inf
+    // from a malfunctioning ADC would silently disable detection
+    // (NaN > threshold is always false). Treat as immediate anomaly.
+    if (!std::isfinite(value)) {
+        if (callback_ != nullptr) {
+            callback_();
+        }
+        in_push_ = false;
+        return;
+    }
+
     buffer_.push(value);
 
     // ---------------------------------------------------------------------------
@@ -17,8 +34,9 @@ void Detector::push_sensor_value(float value) {
     // We always want the most recent INPUT_FEATURES samples in chronological
     // order (oldest first), which is what the inference engine expects.
     //
-    // When the buffer holds fewer than INPUT_FEATURES samples, the leading
+    // When the buffer holds fewer than INPUT_FEATURES samples, the trailing
     // slots are zero-padded so the network sees a consistent input shape.
+    // Samples are left-aligned: [v, 0, 0, 0] for a single-sample cold start.
     // ---------------------------------------------------------------------------
     std::array<float, INPUT_FEATURES> input{};
 
@@ -77,11 +95,24 @@ void Detector::push_sensor_value(float value) {
     dense_forward(weights_l1, bias_l1, input, hidden, Activation::kRelu);
     dense_forward(weights_l2, bias_l2, hidden, output, Activation::kNone);
 
+    // Numeric fault check: if inference produced NaN or Inf (e.g., from
+    // overflow with trained weights), treat as anomaly rather than silently
+    // missing the detection.
+    if (!std::isfinite(output[0])) {
+        if (callback_ != nullptr) {
+            callback_();
+        }
+        in_push_ = false;
+        return;
+    }
+
     // Fire the callback synchronously if an anomaly is detected.
     // The null-check avoids a branch-to-null fault on targets with no MMU.
     if (callback_ != nullptr && output[0] > ANOMALY_THRESHOLD) {
         callback_();
     }
+
+    in_push_ = false;
 }
 
 } // namespace micromind

--- a/tests/test_detector.cpp
+++ b/tests/test_detector.cpp
@@ -1,4 +1,6 @@
+#include <cmath>
 #include <cstddef>
+#include <limits>
 #include <gtest/gtest.h>
 #include "micromind/detector.h"
 
@@ -72,8 +74,8 @@ TEST(Detector, NullCallbackIsSafe) {
 }
 
 // On cold start (fewer than INPUT_FEATURES samples pushed), the missing
-// slots are zero-padded. With only one sample at 1.0f the output is
-// 0.25 * 1.0 = 0.25f which is below threshold — no callback.
+// slots are zero-padded. With only one sample at 1.0f the two-layer pass
+// yields L1 = 0.25, L2 = 0.125 * 0.25 * 8 = 0.25f, below threshold.
 TEST(Detector, ZeroPaddingOnColdStart) {
     reset_callback();
     micromind::Detector det;
@@ -85,4 +87,45 @@ TEST(Detector, ZeroPaddingOnColdStart) {
     det.push_sensor_value(1.0f);
 
     EXPECT_FALSE(g_callback_fired);
+}
+
+// Output exactly at ANOMALY_THRESHOLD (0.5f) must NOT fire the callback,
+// because the comparison is strict greater-than (>), not greater-or-equal.
+// Input [0.5, 0.5, 0.5, 0.5]:
+//   L1 each unit = 0.25*(0.5+0.5+0.5+0.5) = 0.5 -> ReLU -> 0.5
+//   L2 output    = 0.125*0.5*8             = 0.5 == threshold -> no callback
+TEST(Detector, ExactThresholdDoesNotFire) {
+    reset_callback();
+    micromind::Detector det;
+    det.register_callback(recording_callback);
+
+    for (std::size_t i = 0; i < micromind::INPUT_FEATURES; ++i) {
+        det.push_sensor_value(0.5f);
+    }
+
+    EXPECT_FALSE(g_callback_fired);
+}
+
+// A NaN sensor value must be treated as an immediate anomaly — not silently
+// swallowed. NaN > threshold is always false in IEEE 754, so without the
+// guard the callback would never fire.
+TEST(Detector, NaNInputTreatedAsAnomaly) {
+    reset_callback();
+    micromind::Detector det;
+    det.register_callback(recording_callback);
+
+    det.push_sensor_value(std::numeric_limits<float>::quiet_NaN());
+
+    EXPECT_TRUE(g_callback_fired);
+}
+
+// An Inf sensor value must also be treated as an immediate anomaly.
+TEST(Detector, InfInputTreatedAsAnomaly) {
+    reset_callback();
+    micromind::Detector det;
+    det.register_callback(recording_callback);
+
+    det.push_sensor_value(std::numeric_limits<float>::infinity());
+
+    EXPECT_TRUE(g_callback_fired);
 }

--- a/tests/test_detector.cpp
+++ b/tests/test_detector.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <gtest/gtest.h>
 #include "micromind/detector.h"
 
@@ -31,8 +32,9 @@ TEST(Detector, CallbackFiresAboveThreshold) {
     det.register_callback(recording_callback);
 
     // Push INPUT_FEATURES (4) samples large enough to exceed threshold.
-    // output = 0.25 * (1+1+1+1) = 1.0f > 0.5f
-    for (uint32_t i = 0; i < micromind::INPUT_FEATURES; ++i) {
+    // Two-layer pass: L1 each unit = 0.25*(1+1+1+1) = 1.0 -> ReLU -> 1.0
+    //                 L2 output    = 0.125*1.0*8     = 1.0 > 0.5
+    for (std::size_t i = 0; i < micromind::INPUT_FEATURES; ++i) {
         det.push_sensor_value(1.0f);
     }
 
@@ -46,8 +48,9 @@ TEST(Detector, CallbackDoesNotFireBelowThreshold) {
     micromind::Detector det;
     det.register_callback(recording_callback);
 
-    // output = 0.25 * (0+0+0+0) = 0.0f < 0.5f
-    for (uint32_t i = 0; i < micromind::INPUT_FEATURES; ++i) {
+    // Two-layer pass: L1 each unit = 0.25*(0+0+0+0) = 0.0 -> ReLU -> 0.0
+    //                 L2 output    = 0.125*0.0*8     = 0.0 < 0.5
+    for (std::size_t i = 0; i < micromind::INPUT_FEATURES; ++i) {
         det.push_sensor_value(0.0f);
     }
 
@@ -61,7 +64,7 @@ TEST(Detector, NullCallbackIsSafe) {
     det.register_callback(nullptr);
 
     // Would fire if a callback were registered.
-    for (uint32_t i = 0; i < micromind::INPUT_FEATURES; ++i) {
+    for (std::size_t i = 0; i < micromind::INPUT_FEATURES; ++i) {
         det.push_sensor_value(1.0f);
     }
     // Test passes if we reach here without a crash.
@@ -77,7 +80,8 @@ TEST(Detector, ZeroPaddingOnColdStart) {
     det.register_callback(recording_callback);
 
     // Push only one sample — three slots zero-padded.
-    // output = 0.25 * 1.0f = 0.25f < 0.5f
+    // Two-layer pass: L1 each unit = 0.25*1.0 = 0.25 -> ReLU -> 0.25
+    //                 L2 output    = 0.125*0.25*8     = 0.25 < 0.5
     det.push_sensor_value(1.0f);
 
     EXPECT_FALSE(g_callback_fired);

--- a/tests/test_inference.cpp
+++ b/tests/test_inference.cpp
@@ -149,13 +149,13 @@ TEST(DenseForward, NoActivation_PassesThrough)
 
 // Non-zero bias shifts the output by the bias value.
 // weights = [[1, 1]], bias = [0.5], input = [2, 3]
-// pre-activation = 2+3+0.5 = 5.5 -> kNone -> 5.5
+// mat_mul = 1*2 + 1*3 = 5.0, bias = 0.5, output = 5.0 + 0.5 = 5.5
 TEST(DenseForward, BiasCorrectness_ShiftsOutput)
 {
     const float weights[1][2] = { {1.0f, 1.0f} };
     const std::array<float, 1> bias = {0.5f};
     const std::array<float, 2> input = {2.0f, 3.0f};
-    std::array<float, 1> output = {};
+    std::array<float, 1> output = {99.0f};
 
     micromind::dense_forward(weights, bias, input, output,
                              micromind::Activation::kNone);
@@ -196,7 +196,7 @@ TEST(DenseForward, KnownTwoLayerPass_MatchesHandCalc)
     micromind::dense_forward(w2, b2, hidden, output,
                              micromind::Activation::kNone);
 
-    for (std::size_t i = 0; i < 8; ++i) {
+    for (std::size_t i = 0; i < hidden.size(); ++i) {
         EXPECT_FLOAT_EQ(hidden[i], 1.0f);
     }
     EXPECT_FLOAT_EQ(output[0], 1.0f);

--- a/tests/test_inference.cpp
+++ b/tests/test_inference.cpp
@@ -110,3 +110,129 @@ TEST(Relu, AllPositive)
     EXPECT_FLOAT_EQ(arr[1], 2.0f);
     EXPECT_FLOAT_EQ(arr[2], 3.0f);
 }
+
+// ---------------------------------------------------------------------------
+// dense_forward tests
+// ---------------------------------------------------------------------------
+
+// ReLU activation clamps negative pre-activation values to zero.
+// weights = [[1, -2]], bias = [0], input = [1, 1]
+// pre-activation = 1*1 + (-2)*1 + 0 = -1.0 -> ReLU -> 0.0
+TEST(DenseForward, ReluActivation_ClampsNegatives)
+{
+    const float weights[1][2] = { {1.0f, -2.0f} };
+    const std::array<float, 1> bias = {0.0f};
+    const std::array<float, 2> input = {1.0f, 1.0f};
+    std::array<float, 1> output = {99.0f};
+
+    micromind::dense_forward(weights, bias, input, output,
+                             micromind::Activation::kRelu);
+
+    EXPECT_FLOAT_EQ(output[0], 0.0f);
+}
+
+// No activation passes raw values through, including negatives.
+// weights = [[1, -2]], bias = [0], input = [1, 1]
+// pre-activation = -1.0 -> kNone -> -1.0
+TEST(DenseForward, NoActivation_PassesThrough)
+{
+    const float weights[1][2] = { {1.0f, -2.0f} };
+    const std::array<float, 1> bias = {0.0f};
+    const std::array<float, 2> input = {1.0f, 1.0f};
+    std::array<float, 1> output = {99.0f};
+
+    micromind::dense_forward(weights, bias, input, output,
+                             micromind::Activation::kNone);
+
+    EXPECT_FLOAT_EQ(output[0], -1.0f);
+}
+
+// Non-zero bias shifts the output by the bias value.
+// weights = [[1, 1]], bias = [0.5], input = [2, 3]
+// pre-activation = 2+3+0.5 = 5.5 -> kNone -> 5.5
+TEST(DenseForward, BiasCorrectness_ShiftsOutput)
+{
+    const float weights[1][2] = { {1.0f, 1.0f} };
+    const std::array<float, 1> bias = {0.5f};
+    const std::array<float, 2> input = {2.0f, 3.0f};
+    std::array<float, 1> output = {};
+
+    micromind::dense_forward(weights, bias, input, output,
+                             micromind::Activation::kNone);
+
+    EXPECT_FLOAT_EQ(output[0], 5.5f);
+}
+
+// Full two-layer pass matching the spec's hand-calculated values.
+// Layer 1: 8x4 weights all 0.25, bias all 0.0, input [1,1,1,1]
+//   each hidden unit = 0.25*4 = 1.0 -> ReLU -> 1.0
+// Layer 2: 1x8 weights all 0.125, bias all 0.0
+//   output = 0.125*8 = 1.0
+TEST(DenseForward, KnownTwoLayerPass_MatchesHandCalc)
+{
+    const float w1[8][4] = {
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f},
+        {0.25f, 0.25f, 0.25f, 0.25f}
+    };
+    const std::array<float, 8> b1 = {};
+    const float w2[1][8] = {
+        {0.125f, 0.125f, 0.125f, 0.125f,
+         0.125f, 0.125f, 0.125f, 0.125f}
+    };
+    const std::array<float, 1> b2 = {};
+
+    const std::array<float, 4> input = {1.0f, 1.0f, 1.0f, 1.0f};
+    std::array<float, 8> hidden = {};
+    std::array<float, 1> output = {};
+
+    micromind::dense_forward(w1, b1, input, hidden,
+                             micromind::Activation::kRelu);
+    micromind::dense_forward(w2, b2, hidden, output,
+                             micromind::Activation::kNone);
+
+    for (std::size_t i = 0; i < 8; ++i) {
+        EXPECT_FLOAT_EQ(hidden[i], 1.0f);
+    }
+    EXPECT_FLOAT_EQ(output[0], 1.0f);
+}
+
+// Two-layer pass with mixed-sign layer 1 weights: negative hidden units
+// are clamped by ReLU and must not contribute to the output.
+//
+// Layer 1 (2x2): weights = [[1, 1], [-1, -1]], bias = [0, 0]
+//   input = [1, 1]
+//   hidden[0] = 1+1 = 2.0 -> ReLU -> 2.0
+//   hidden[1] = -1-1 = -2.0 -> ReLU -> 0.0
+// Layer 2 (1x2): weights = [[1, 1]], bias = [0]
+//   output = 1*2.0 + 1*0.0 = 2.0 (NOT 0.0 if ReLU were missing)
+TEST(DenseForward, NegativeHiddenUnits_ClampedByRelu)
+{
+    const float w1[2][2] = {
+        { 1.0f,  1.0f},
+        {-1.0f, -1.0f}
+    };
+    const std::array<float, 2> b1 = {};
+    const float w2[1][2] = {
+        {1.0f, 1.0f}
+    };
+    const std::array<float, 1> b2 = {};
+
+    const std::array<float, 2> input = {1.0f, 1.0f};
+    std::array<float, 2> hidden = {};
+    std::array<float, 1> output = {};
+
+    micromind::dense_forward(w1, b1, input, hidden,
+                             micromind::Activation::kRelu);
+    micromind::dense_forward(w2, b2, hidden, output,
+                             micromind::Activation::kNone);
+
+    EXPECT_FLOAT_EQ(hidden[0], 2.0f);
+    EXPECT_FLOAT_EQ(hidden[1], 0.0f);
+    EXPECT_FLOAT_EQ(output[0], 2.0f);
+}


### PR DESCRIPTION
## Summary

- Add composable `dense_forward` template wrapping `mat_vec_mul` + bias + activation tag (`kRelu`/`kNone`)
- Replace single-layer detector pass with two-layer forward: input(4) -> hidden(8, ReLU) -> output(1)
- Add `HIDDEN_UNITS`, `LAYER1_BIAS_INIT`, `LAYER2_BIAS_INIT` to config with `static_assert` safety guards
- Add project-level `CLAUDE.md` documenting C++14 override and embedded constraints

## Test Plan

- [x] 5 new `dense_forward` tests (ReLU clamping, pass-through, bias shift, two-layer composition, negative hidden unit gating)
- [x] 4 existing detector tests pass unchanged (behavioral outcomes identical under two-layer math)
- [x] 27/27 tests pass on clean rebuild with zero warnings under `-Wall -Wextra -Werror`

Closes #2