### PR TITLE
docs(license): rename copyright holder from raivolld to Oliver Raider

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2026 raivolld
+Copyright 2026 Oliver Raider
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the LICENSE file to replace the old username `raivolld` with the correct legal name `Oliver Raider`.